### PR TITLE
Check bobber owner before rethrowing

### DIFF
--- a/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
+++ b/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
@@ -12,10 +12,14 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Objects;
+
 @Mixin(FishingBobberEntity.class)
 public abstract class AutofishMixin {
 	@Shadow
 	private boolean caughtFish;
+
+
 
 	@Inject(at = {@At("TAIL")}, method = {"onTrackedDataSet"})
 	public void onTrackedDataSet(TrackedData<?> data, CallbackInfo ci) throws InterruptedException {
@@ -24,11 +28,11 @@ public abstract class AutofishMixin {
 
 		}
 
+		FishingBobberEntity bobber = (FishingBobberEntity)(Object) this;
+
 		MinecraftClient client = MinecraftClient.getInstance();
-		if (caughtFish) {
 
-
-
+		if (caughtFish && Objects.requireNonNull(client.player).equals(bobber.getPlayerOwner())) {
 			if (!Autofish.on){
 				client.interactionManager.interactItem(client.player, Hand.MAIN_HAND);
 				Thread.sleep(5L);

--- a/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
+++ b/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
@@ -3,6 +3,7 @@ package net.genesis.autofish.mixin;
 
 import net.genesis.autofish.Autofish;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.entity.projectile.FishingBobberEntity;
 import net.minecraft.entity.data.TrackedData;
@@ -21,6 +22,10 @@ public abstract class AutofishMixin {
 	private boolean caughtFish;
 
 
+	@Shadow
+	public abstract PlayerEntity getPlayerOwner();
+
+
 
 	@Inject(at = {@At("TAIL")}, method = {"onTrackedDataSet"})
 	public void onTrackedDataSet(TrackedData<?> data, CallbackInfo ci) throws InterruptedException {
@@ -28,12 +33,9 @@ public abstract class AutofishMixin {
 			Autofish.on = !Autofish.on;
 
 		}
-
-		FishingBobberEntity bobber = (FishingBobberEntity)(Object) this;
-
 		MinecraftClient client = MinecraftClient.getInstance();
 
-		if (caughtFish && bobber.getPlayerOwner() instanceof ClientPlayerEntity) {
+		if (caughtFish && getPlayerOwner() instanceof ClientPlayerEntity) {
 			if (!Autofish.on){
 				client.interactionManager.interactItem(client.player, Hand.MAIN_HAND);
 				Thread.sleep(5L);

--- a/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
+++ b/src/main/java/net/genesis/autofish/mixin/AutofishMixin.java
@@ -2,6 +2,7 @@ package net.genesis.autofish.mixin;
 
 
 import net.genesis.autofish.Autofish;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.entity.projectile.FishingBobberEntity;
 import net.minecraft.entity.data.TrackedData;
@@ -32,7 +33,7 @@ public abstract class AutofishMixin {
 
 		MinecraftClient client = MinecraftClient.getInstance();
 
-		if (caughtFish && Objects.requireNonNull(client.player).equals(bobber.getPlayerOwner())) {
+		if (caughtFish && bobber.getPlayerOwner() instanceof ClientPlayerEntity) {
 			if (!Autofish.on){
 				client.interactionManager.interactItem(client.player, Hand.MAIN_HAND);
 				Thread.sleep(5L);


### PR DESCRIPTION
If you do fishing at multiplayer, any catched fish by any player causes a bobber rethrow, even if you didnt catch a fish yourself.
This pull request fixes such an issue, by checking bobber's owner before rethrowing.